### PR TITLE
プレイヤーに走るアニメーションを追加

### DIFF
--- a/AssaultRifle.cpp
+++ b/AssaultRifle.cpp
@@ -52,13 +52,13 @@ void AssaultRifle::InitializeBulletData(VECTOR cameraPosition, VECTOR targetPosi
 /// 更新
 /// </summary>
 void AssaultRifle::Update(VECTOR setPosition, VECTOR cameraVector, VECTOR cameraTargetVector,
-    VECTOR cameraPosition, float cameraPitch)
+    VECTOR cameraPosition, float cameraPitch, Player::State playerState)
 {
     // 座標を更新
     position = setPosition;
 
     // 角度を更新
-    UpdateAngle(cameraVector, cameraPitch);
+    //UpdateAngle(cameraVector, cameraPitch);
 
     // 座標の設定
     MV1SetPosition(modelHandle, position);

--- a/AssaultRifle.cpp
+++ b/AssaultRifle.cpp
@@ -58,7 +58,6 @@ void AssaultRifle::Update(VECTOR setPosition, VECTOR cameraVector, VECTOR camera
     position = setPosition;
 
     // 角度を更新
-    //UpdateAngle(cameraVector, cameraPitch);
 
     // 座標の設定
     MV1SetPosition(modelHandle, position);

--- a/AssaultRifle.h
+++ b/AssaultRifle.h
@@ -35,7 +35,7 @@ public:
     /// 更新
     /// </summary>
     void Update(VECTOR setPosition, VECTOR cameraVector,  VECTOR cameraTargetVector,
-        VECTOR cameraPosition, float cameraPitch) override;
+        VECTOR cameraPosition, float cameraPitch, Player::State playerState) override;
 
     /// <summary>
     /// 描画

--- a/BattleRifle.cpp
+++ b/BattleRifle.cpp
@@ -58,7 +58,6 @@ void BattleRifle:: Update(VECTOR setPosition, VECTOR cameraVector, VECTOR camera
     position = setPosition;
 
     // 角度を更新
-    //UpdateAngle(cameraVector, cameraPitch);
 
     // 座標の設定
     MV1SetPosition(modelHandle, position);

--- a/BattleRifle.cpp
+++ b/BattleRifle.cpp
@@ -52,13 +52,13 @@ void BattleRifle::InitializeBulletData(VECTOR cameraPosition, VECTOR targetPosit
 /// 更新
 /// </summary>
 void BattleRifle:: Update(VECTOR setPosition, VECTOR cameraVector, VECTOR cameraTargetVector,
-    VECTOR cameraPosition, float cameraPitch)
+    VECTOR cameraPosition, float cameraPitch, Player::State playerState)
 {
     // 座標を更新
     position = setPosition;
 
     // 角度を更新
-    UpdateAngle(cameraVector, cameraPitch);
+    //UpdateAngle(cameraVector, cameraPitch);
 
     // 座標の設定
     MV1SetPosition(modelHandle, position);

--- a/BattleRifle.h
+++ b/BattleRifle.h
@@ -35,7 +35,7 @@ public:
     /// 更新
     /// </summary>
     void Update(VECTOR setPosition, VECTOR cameraVector, VECTOR cameraTargetVector,
-        VECTOR cameraPosition, float cameraPitch) override;
+        VECTOR cameraPosition, float cameraPitch, Player::State playerState) override;
 
     /// <summary>
     /// 描画

--- a/CollisionManager.cpp
+++ b/CollisionManager.cpp
@@ -19,31 +19,8 @@ CollisionManager::~CollisionManager()
 {
     // メモリ解放 //
 
-    // 球型の当たり判定
-    for (int i = 0; i < sphereCollisionData.size(); i++)
-    {
-        delete(sphereCollisionData[i]);
-    }
-
-    // カプセル型の当たり判定
-    for (int i = 0; i < capsuleCollisionData.size(); i++)
-    {
-        delete(capsuleCollisionData[i]);
-    }
-
-    // 線分型の当たり判定
-    for (int i = 0; i < lineCollisionData.size(); i++)
-    {
-        delete(lineCollisionData[i]);
-    }
-
-
     // 当たり判定情報リスト
     collisionDataList.clear();
-    for (int i = 0; i < collisionDataList.size(); i++)
-    {
-        delete(collisionDataList[i]);
-    }
 
 }
 

--- a/GunBase.cpp
+++ b/GunBase.cpp
@@ -1,4 +1,4 @@
-﻿#include "GunBase.h"\\\//////////////////////////////////////////////////////////////////////////////////\
+﻿#include "GunBase.h"
 
 /// <summary>
 /// コンストラクタ
@@ -71,7 +71,7 @@ void GunBase::UpdateAngle(VECTOR cameraForwardVector, float pitch,Player::State 
 
         // 回転行列を取得
         MATRIX runMatrixY = MGetRotY(angle);
-        MATRIX runMatrixX = MGetRotX(0.2f);
+        MATRIX runMatrixX = MGetRotX(RunAnimationAngle);
         MATRIX runFinalMatrix = MMult(runMatrixX, runMatrixY);
 
         // 回転行列を合成
@@ -88,12 +88,16 @@ void GunBase::UpdateAngle(VECTOR cameraForwardVector, float pitch,Player::State 
 /// <param name="cameraForwardVector"></param>
 void GunBase::FixedGunPosition(VECTOR setPosition, VECTOR cameraForwardVector)
 {
+    // カメラから平行なベクトル
     VECTOR horizonDirection = VGet(cameraForwardVector.x, 0.0f, cameraForwardVector.z);
 
+    // 正規化
     VECTOR velocity = VNorm(horizonDirection);
 
-    VECTOR offset = VScale(velocity, -0.7f);
+    // ずらし量を計算
+    VECTOR offset = VScale(velocity, HipUpPositionOffsetScale);
     position = VAdd(position, offset);
 
+    // 座標を設定
     MV1SetPosition(modelHandle, position);
 }

--- a/GunBase.cpp
+++ b/GunBase.cpp
@@ -52,19 +52,29 @@ void GunBase::UpdateAngle(VECTOR cameraForwardVector, float pitch,Player::State 
     MATRIX rotationY = MGetRotY(gunAngleY);
     MATRIX rotationZ = MGetRotZ(0.0f);
 
+    // 回転行列を合成
     rotationMatrix = MMult(rotationX, rotationY);
 
     // 走るアニメーションを再生
     if (playerState == Player::State::Run)
     {
+        // アニメーションカウントを進める
         runAnimationCount++;
 
-        float angle = Player::RunAnimationLimitAngle *
-            sin(DX_TWO_PI_F * runAnimationCount / Player::RunAnimationFrameCycle);
+        // 回転角度を設定
+        // sin関数で[1]～[-1]を出してもらう
+        // (アニメーションカウントを再生周期で割ることで現在どのくらい進んでいるかが分かる)
+        float animationProgress = sin(DX_TWO_PI_F * runAnimationCount / Player::RunAnimationFrameCycle);
+        // 最大アングル * [１～ -１] = 角度
+        // sinを使うことでマイナスの条件式を省く
+        float angle = Player::RunAnimationLimitAngle * animationProgress;
 
+        // 回転行列を取得
         MATRIX runMatrixY = MGetRotY(angle);
         MATRIX runMatrixX = MGetRotX(0.2f);
         MATRIX runFinalMatrix = MMult(runMatrixX, runMatrixY);
+
+        // 回転行列を合成
         rotationMatrix = MMult(runFinalMatrix, rotationMatrix);
     }
 

--- a/GunBase.h
+++ b/GunBase.h
@@ -1,6 +1,7 @@
 ﻿#pragma once
 #include "Common.h"
 #include "Bullet.h"
+#include "Player.h"
 
 class   GunStateBase;
 enum    GunState;
@@ -47,7 +48,7 @@ public:
     /// 更新
     /// </summary>
     virtual void Update(VECTOR setPosition, VECTOR cameraVector,VECTOR cameraTargetVector,
-        VECTOR cameraPosition, float cameraPitch) abstract;
+        VECTOR cameraPosition, float cameraPitch,Player::State) abstract;
 
     /// <summary>
     /// 描画
@@ -62,11 +63,18 @@ public:
 
 protected:
     /// <summary>
+    /// 移動の更新
+    /// </summary>
+    /// <param name="setPosition">設定したい座標</param>
+    /// <param name="playerState">プレイヤーの状態</param>
+    virtual void UpdateMove(VECTOR setPosition, Player::State playerState);
+
+    /// <summary>
     /// 回転の更新
     /// </summary>
     /// <param name="cameraForwardVector">カメラの前ベクトル</param>
     /// <param name="pitch">上下角度</param>
-    void UpdateAngle(VECTOR cameraForwardVector,float pitch);
+    void UpdateAngle(VECTOR cameraForwardVector, float pitch, Player::State playerState);
 
     // 銃の位置調整
     void FixedGunPosition(VECTOR setPosition,VECTOR cameraForwardVector);
@@ -78,22 +86,31 @@ protected:
     // 腰だめ
     static constexpr float  HipUpPositionAngleY     = 3.0f * DX_PI_F / 180.0f;      // 水平回転用：腰だめの位置に調整するために回転させるY軸回転度(ラジアン)
     static constexpr float  HipUpPositionANglePitch = 30.0f * DX_PI_F / 180.0f;     // 垂直回転用：腰だめの位置に調整するために回転させる水平方向からの角度(ラジアン)
+    // アニメーション
+
 
     //---------------------------------------------------------------------------------//
     //                                      変数                                       //
     //---------------------------------------------------------------------------------//
-    Bullet::BulletInitializeData bulletData;    // 弾丸のデータ
-    list<Bullet*>   activeBullet;               // 使用中の弾丸
+    // ステータス
     int             modelHandle;                // モデルハンドル
     VECTOR          position;                   // 座標
     VECTOR          positionOffsetAmount;       // 座標をずらす量
+    MATRIX          rotationMatrix;             // モデルの回転行列
     GunState        state;                      // 銃の状態
     GunStateBase*   currentState;               // 現在の銃の更新を行う状態
-    float           bulletDamagePower;          // 弾丸の威力
-    float           bulletPenetrationPower;     // 弾丸の貫通力
     int             fireRate;                   // 銃の連射力
     float           recoil;                     // 銃の反動
     float           accuracy;                   // 銃の精度(拡散度合い)
+
+    // 弾丸
+    Bullet::BulletInitializeData bulletData;    // 弾丸のデータ
+    list<Bullet*>   activeBullet;               // 使用中の弾丸
+    float           bulletDamagePower;          // 弾丸の威力
+    float           bulletPenetrationPower;     // 弾丸の貫通力
+
+    // アニメーション
+    int             runAnimationCount;          // 銃のアニメーションカウント
 };
 
 

--- a/GunBase.h
+++ b/GunBase.h
@@ -84,10 +84,11 @@ protected:
     //                                      変数                                       //
     //---------------------------------------------------------------------------------//
     // 腰だめ
-    static constexpr float  HipUpPositionAngleY     = 3.0f * DX_PI_F / 180.0f;      // 水平回転用：腰だめの位置に調整するために回転させるY軸回転度(ラジアン)
-    static constexpr float  HipUpPositionANglePitch = 30.0f * DX_PI_F / 180.0f;     // 垂直回転用：腰だめの位置に調整するために回転させる水平方向からの角度(ラジアン)
+    static constexpr float  HipUpPositionAngleY         = 3.0f * DX_PI_F / 180.0f;      // 水平回転用：腰だめの位置に調整するために回転させるY軸回転度(ラジアン)
+    static constexpr float  HipUpPositionANglePitch     = 30.0f * DX_PI_F / 180.0f;     // 垂直回転用：腰だめの位置に調整するために回転させる水平方向からの角度(ラジアン)
+    static constexpr float  HipUpPositionOffsetScale    = -0.7f;                        // 腰だめのずらし量の拡大率
     // アニメーション
-
+    static constexpr float  RunAnimationAngle           = 15.0f * DX_PI_F / 180.0f; // 走りアニメーション再生時の銃の修正角度
 
     //---------------------------------------------------------------------------------//
     //                                      変数                                       //

--- a/GunBase.h
+++ b/GunBase.h
@@ -76,9 +76,12 @@ protected:
     /// <param name="pitch">上下角度</param>
     void UpdateAngle(VECTOR cameraForwardVector, float pitch, Player::State playerState);
 
-    // 銃の位置調整
+    /// <summary>
+    /// 銃の位置調整
+    /// </summary>
+    /// <param name="setPosition">設定したい座標</param>
+    /// <param name="cameraForwardVector">カメラの前方向ベクトル</param>
     void FixedGunPosition(VECTOR setPosition,VECTOR cameraForwardVector);
-
 
     //---------------------------------------------------------------------------------//
     //                                      変数                                       //

--- a/MyDxLibGame3D.vcxproj.filters
+++ b/MyDxLibGame3D.vcxproj.filters
@@ -441,5 +441,8 @@
     <ClInclude Include="BulletObjectPools.h">
       <Filter>ZombiFPS\GameObject\Player\Gun\Bullet\BulletObjectPools</Filter>
     </ClInclude>
+    <ClInclude Include="CollisionData.h">
+      <Filter>ZombiFPS\CollisionManager</Filter>
+    </ClInclude>
   </ItemGroup>
 </Project>

--- a/Player.cpp
+++ b/Player.cpp
@@ -82,6 +82,7 @@ void Player::Initialize()
     animationData.currentAnimationCount     = currentAnimationCount;
     animationData.previousAnimationCount    = previousAnimationCount;
     animationData.previousPlayAnimation     = previousPlayAnimation;
+    animationData.animationFactor           = 0.0f;
 }
 
 /// <summary>
@@ -91,13 +92,13 @@ void Player::Initialize()
 /// <param name="stage">ステージ</param>
 void Player::Update(const Input& input, Stage& stage)
 {
-    // 移動更新
-    UpdateMovement(input, stage);
-
     // 現在のステートの更新
     TransitionInputState(input);
     ChangeState(state);
     currentState->Update();
+
+    // 移動更新
+    UpdateMovement(input, stage);
 
     // 射撃更新
     UpdateShootingEquippedWeapon(input);
@@ -421,11 +422,8 @@ void Player::Move(const VECTOR& MoveVector, Stage& stage)
     // MEMO:走りアニメーション再生時にY座標のみ下にしたいため別のVECTORを用意
     VECTOR movePosition = position;
 
-    // 走りステート時に座標修正
-    FixedRunPosition();
-
     // 現在の適用率に基づいてオフセットを計算
-    VECTOR offset   = VScale(RunAnimationOffset, runAnimationLerpFactor);
+    VECTOR offset   = currentState->GetStateOffseValue();
     movePosition    = VAdd(position, offset);
 
     // プレイヤーのモデルの座標を更新する

--- a/Player.cpp
+++ b/Player.cpp
@@ -490,32 +490,6 @@ void Player::UpdateAngle()
 }
 
 /// <summary>
-/// 走りステート時の座標の調整
-/// </summary>
-void Player::FixedRunPosition()
-{
-    // 走りアニメーション時の処理
-    if (state == State::Run)
-    {
-        // アニメーションの適用率を増加
-        runAnimationLerpFactor += RunAnimationFactorSpeed;
-        if (runAnimationLerpFactor > 1.0f)
-        {
-            runAnimationLerpFactor = 1.0f;
-        }
-    }
-    else
-    {
-        // 他の状態に移行した場合、適用率を減少
-        runAnimationLerpFactor -= RunAnimationFactorSpeed;
-        if (runAnimationLerpFactor < 0.0f)
-        {
-            runAnimationLerpFactor = 0.0f;
-        }
-    }
-}
-  
-/// <summary>
 /// プレイヤーのアニメーションを新しく追加する
 /// </summary>
 /// <param name="PlayAnimation">再生したいアニメーション番号</param>

--- a/Player.cpp
+++ b/Player.cpp
@@ -425,8 +425,8 @@ void Player::Move(const VECTOR& MoveVector, Stage& stage)
     FixedRunPosition();
 
     // 現在の適用率に基づいてオフセットを計算
-    VECTOR offset = VScale(RunAnimationOffset, runAnimationLerpFactor);
-    movePosition = VAdd(position, offset);
+    VECTOR offset   = VScale(RunAnimationOffset, runAnimationLerpFactor);
+    movePosition    = VAdd(position, offset);
 
     // プレイヤーのモデルの座標を更新する
     MV1SetPosition(modelHandle, movePosition);

--- a/Player.cpp
+++ b/Player.cpp
@@ -423,7 +423,7 @@ void Player::Move(const VECTOR& MoveVector, Stage& stage)
     VECTOR movePosition = position;
 
     // 現在の適用率に基づいてオフセットを計算
-    VECTOR offset   = currentState->GetStateOffseValue();
+    VECTOR offset   = currentState->GetStateOffsetValue();
     movePosition    = VAdd(position, offset);
 
     // プレイヤーのモデルの座標を更新する

--- a/Player.h
+++ b/Player.h
@@ -105,6 +105,7 @@ public:
     static constexpr VECTOR RunAnimationOffset      = { 0.0f,-0.5f,0.0f };  // 走りアニメーション再生時のずらし量
     static constexpr float  RunAnimationLimitAngle  = 0.3f;                 // 走りアニメーション中に回転させる最大角度
     static constexpr float  RunAnimationFrameCycle  = 60.0f;                // 走りアニメーションを再生する周期
+    static constexpr float  RunAnimationFactorSpeed = 0.1f;                 // 走りアニメーションの適応速度
 
 private:
     /// <summary>
@@ -160,6 +161,11 @@ private:
     /// </summary>
     /// <param name="type">アニメーションの種類</param>
     void PlayAnimation(AnimationType type);
+
+    /// <summary>
+    /// 走りステート時の座標の調整
+    /// </summary>
+    void FixedRunPosition();
 
     /// <summary>
     /// 銃を撃つ
@@ -242,5 +248,6 @@ private:
     float       animationBlendRate;                 // 現在と過去のアニメーションのブレンド率
     PlayerStateBase::AnimationData animationData;   // アニメーション再生に必要なデータ
     int         runAnimationCount;                  // 走りアニメーションを再生するカウント
+    float       runAnimationLerpFactor;
 };
 

--- a/Player.h
+++ b/Player.h
@@ -89,13 +89,22 @@ public:
     /// </summary>
     void OnHitFloor();
 
-    // ゲッター、セッター
+    //---------------------------------------------------------------------------------//
+    //                                Getter/Setter                                    //
+    //---------------------------------------------------------------------------------//
     const VECTOR& GetPosition() const { return position; }
     bool GetCurrentFrameMove() const { return currentFrameMove; }
     bool GetIsShooting()const { return isShooting; }
     State GetState() const { return state; }
     float GetCurrentJumpPower() const { return currentJumpPower; }
     const MATRIX GetRotationMatrix()const { return rotationMatrix; }
+
+    //---------------------------------------------------------------------------------//
+    //                                      定数                                       //
+    //---------------------------------------------------------------------------------//
+    static constexpr VECTOR RunAnimationOffset      = { 0.0f,-0.5f,0.0f };  // 走りアニメーション再生時のずらし量
+    static constexpr float  RunAnimationLimitAngle  = 0.3f;                 // 走りアニメーション中に回転させる最大角度
+    static constexpr float  RunAnimationFrameCycle  = 60.0f;                // 走りアニメーションを再生する周期
 
 private:
     /// <summary>
@@ -175,7 +184,6 @@ private:
     /// <param name="newState">新しいステート</param>
     void ChangeState(State newState);
 
-
     //---------------------------------------------------------------------------------//
     //                                      定数                                       //
     //---------------------------------------------------------------------------------//
@@ -233,5 +241,6 @@ private:
     float       previousAnimationCount;             // 前の再生アニメーションの再生時間
     float       animationBlendRate;                 // 現在と過去のアニメーションのブレンド率
     PlayerStateBase::AnimationData animationData;   // アニメーション再生に必要なデータ
+    int         runAnimationCount;                  // 走りアニメーションを再生するカウント
 };
 

--- a/Player.h
+++ b/Player.h
@@ -163,11 +163,6 @@ private:
     void PlayAnimation(AnimationType type);
 
     /// <summary>
-    /// 走りステート時の座標の調整
-    /// </summary>
-    void FixedRunPosition();
-
-    /// <summary>
     /// 銃を撃つ
     /// </summary>
     /// <param name="input">入力情報</param>

--- a/PlayerIdleState.cpp
+++ b/PlayerIdleState.cpp
@@ -34,6 +34,9 @@ PlayerIdleState::~PlayerIdleState()
 /// </summary>
 void PlayerIdleState::Update()
 {
+    // プレイヤーの座標修正
+    FixedPosition();
+
     // アニメーションの更新
     UpdateAnimation();
 
@@ -41,14 +44,4 @@ void PlayerIdleState::Update()
     UpdateAnimationData();
 }
 
-/// <summary>
-/// アニメーションデータの更新
-/// </summary>
-void PlayerIdleState::UpdateAnimationData()
-{
-    nowStateData.currentAnimationCount  = currentAnimationCount;
-    nowStateData.currentPlayAnimation   = currentPlayAnimation;
-    nowStateData.previousAnimationCount = previousAnimationCount;
-    nowStateData.previousPlayAnimation  = previousPlayAnimation;
-}
 

--- a/PlayerIdleState.cpp
+++ b/PlayerIdleState.cpp
@@ -35,7 +35,7 @@ PlayerIdleState::~PlayerIdleState()
 void PlayerIdleState::Update()
 {
     // プレイヤーの座標修正
-    FixedPosition();
+    UpdateOffsetValue();
 
     // アニメーションの更新
     UpdateAnimation();

--- a/PlayerIdleState.h
+++ b/PlayerIdleState.h
@@ -32,10 +32,6 @@ public:
 
 
 private:
-    /// <summary>
-    /// アニメーションデータの更新
-    /// </summary>
-    void UpdateAnimationData();
 
     // アニメーション
     static constexpr float  PlayAnimationSpeed = 0.5f;                         // アニメーション速度

--- a/PlayerRunState.cpp
+++ b/PlayerRunState.cpp
@@ -35,7 +35,7 @@ PlayerRunState::~PlayerRunState()
 void PlayerRunState::Update()
 {
     // プレイヤーの座標修正
-    FixedPosition();
+    UpdateOffsetValue();
 
     // アニメーションの更新
     UpdateAnimation();
@@ -47,7 +47,7 @@ void PlayerRunState::Update()
 /// <summary>
 /// プレイヤーの座標の修正
 /// </summary>
-void PlayerRunState::FixedPosition()
+void PlayerRunState::UpdateOffsetValue()
 {
     // アニメーションの適用率を上昇
     // 上昇させることで腕を下げる

--- a/PlayerRunState.cpp
+++ b/PlayerRunState.cpp
@@ -34,6 +34,9 @@ PlayerRunState::~PlayerRunState()
 /// </summary>
 void PlayerRunState::Update()
 {
+    // プレイヤーの座標修正
+    FixedPosition();
+
     // アニメーションの更新
     UpdateAnimation();
 
@@ -42,14 +45,18 @@ void PlayerRunState::Update()
 }
 
 /// <summary>
-/// アニメーションデータの更新
+/// プレイヤーの座標の修正
 /// </summary>
-void PlayerRunState::UpdateAnimationData()
+void PlayerRunState::FixedPosition()
 {
-    nowStateData.currentAnimationCount  = currentAnimationCount;
-    nowStateData.currentPlayAnimation   = currentPlayAnimation;
-    nowStateData.previousAnimationCount = previousAnimationCount;
-    nowStateData.previousPlayAnimation  = previousPlayAnimation;
+    // アニメーションの適用率を上昇
+    // 上昇させることで腕を下げる
+    animationFactor += RunAnimationSpeed;
+    if (animationFactor > 1.0f)
+    {
+        animationFactor = 1.0f;
+    }
+
+    // 走りステートのずらし量を決める
+    stateOffsetValue = VScale(RunAnimationOffsetValue,animationFactor);
 }
-
-

--- a/PlayerRunState.h
+++ b/PlayerRunState.h
@@ -36,8 +36,10 @@ private:
     void UpdateAnimationData();
 
     // アニメーション
-    static constexpr float  PlayAnimationSpeed = 0.5f;                         // アニメーション速度
-    static constexpr float  AnimationBlendSpeed = 0.1f;                         // アニメーションのブレンド率変化速度
+    static constexpr float  PlayAnimationSpeed = 0.5f;              // アニメーション速度
+    static constexpr float  AnimationBlendSpeed = 0.1f;             // アニメーションのブレンド率変化速度
+
+
 
 };
 

--- a/PlayerRunState.h
+++ b/PlayerRunState.h
@@ -34,7 +34,7 @@ private:
     /// <summary>
     /// プレイヤーの座標修正
     /// </summary>
-    void FixedPosition() override;
+    void UpdateOffsetValue() override;
 
     // アニメーション
     static constexpr float  PlayAnimationSpeed      = 0.5f;     // アニメーション速度

--- a/PlayerRunState.h
+++ b/PlayerRunState.h
@@ -30,16 +30,17 @@ public:
     void Update() override;
 
 private:
+
     /// <summary>
-    /// アニメーションデータの更新
+    /// プレイヤーの座標修正
     /// </summary>
-    void UpdateAnimationData();
+    void FixedPosition() override;
 
     // アニメーション
-    static constexpr float  PlayAnimationSpeed = 0.5f;              // アニメーション速度
-    static constexpr float  AnimationBlendSpeed = 0.1f;             // アニメーションのブレンド率変化速度
-
-
+    static constexpr float  PlayAnimationSpeed      = 0.5f;     // アニメーション速度
+    static constexpr float  AnimationBlendSpeed     = 0.1f;     // アニメーションのブレンド率変化速度
+    static constexpr float  RunAnimationSpeed       = 0.1f;     // 走るアニメーションの再生速度
+    static constexpr VECTOR RunAnimationOffsetValue = { 0.0f,-0.5f,0.0f };  // 走りステート時のずらし量
 
 };
 

--- a/PlayerStateBase.cpp
+++ b/PlayerStateBase.cpp
@@ -134,7 +134,7 @@ void PlayerStateBase::UpdateAnimation()
 /// <summary>
 /// プレイヤーのステートごとの座標修正
 /// </summary>
-/// Fixed:オーバーライドさせている分のifをベース側の関数でまとめて
+/// TODO :オーバーライドさせている分のifをベース側の関数でまとめて
 ///       加算する符号、オフセット量、再生速度、引数で受け取れるようにする
 void PlayerStateBase::UpdateOffsetValue()
 {

--- a/PlayerStateBase.cpp
+++ b/PlayerStateBase.cpp
@@ -143,4 +143,19 @@ void PlayerStateBase::FixedPosition()
     {
         animationFactor = 0.0f;
     }
+
+    // 現在のステートのずらし量を決める
+    stateOffsetValue = VScale(AnimationOffsetValue, animationFactor);
+}
+
+/// <summary>
+/// アニメーションデータの更新
+/// </summary>
+void PlayerStateBase::UpdateAnimationData()
+{
+    nowStateData.currentAnimationCount  = currentAnimationCount;
+    nowStateData.currentPlayAnimation   = currentPlayAnimation;
+    nowStateData.previousAnimationCount = previousAnimationCount;
+    nowStateData.previousPlayAnimation  = previousPlayAnimation;
+    nowStateData.animationFactor        = animationFactor;
 }

--- a/PlayerStateBase.cpp
+++ b/PlayerStateBase.cpp
@@ -134,6 +134,8 @@ void PlayerStateBase::UpdateAnimation()
 /// <summary>
 /// プレイヤーのステートごとの座標修正
 /// </summary>
+/// Fixed:オーバーライドさせている分のifをベース側の関数でまとめて
+///       加算する符号、オフセット量、再生速度、引数で受け取れるようにする
 void PlayerStateBase::UpdateOffsetValue()
 {
     // 適用率を減少させる

--- a/PlayerStateBase.cpp
+++ b/PlayerStateBase.cpp
@@ -134,7 +134,7 @@ void PlayerStateBase::UpdateAnimation()
 /// <summary>
 /// プレイヤーのステートごとの座標修正
 /// </summary>
-void PlayerStateBase::FixedPosition()
+void PlayerStateBase::UpdateOffsetValue()
 {
     // 適用率を減少させる
     // Run,Reloadステートで適用率を上昇させることでポジションを下げる

--- a/PlayerStateBase.cpp
+++ b/PlayerStateBase.cpp
@@ -20,6 +20,7 @@ PlayerStateBase::PlayerStateBase(int playerModelHandle, AnimationData previousSt
     , currentPlayAnimation                  (previousStateData.currentPlayAnimation)
     , previousAnimationCount                (previousStateData.previousAnimationCount)
     , previousPlayAnimation                 (previousStateData.previousPlayAnimation)
+    , animationFactor                       (previousStateData.animationFactor)
 {
     nowStateData.currentAnimationCount  = 0;
     nowStateData.currentPlayAnimation   = 0;
@@ -127,5 +128,19 @@ void PlayerStateBase::UpdateAnimation()
         // アニメーション２のモデルに対する反映率をセット
         MV1SetAttachAnimBlendRate(modelHandle, previousPlayAnimation,
             MaxAnimationBlendRate - animationBlendRate);
+    }
+}
+
+/// <summary>
+/// プレイヤーのステートごとの座標修正
+/// </summary>
+void PlayerStateBase::FixedPosition()
+{
+    // 適用率を減少させる
+    // Run,Reloadステートで適用率を上昇させることでポジションを下げる
+    animationFactor -= AnimationFactorSpeed;
+    if (animationFactor < 0.0f)
+    {
+        animationFactor = 0.0f;
     }
 }

--- a/PlayerStateBase.h
+++ b/PlayerStateBase.h
@@ -81,6 +81,8 @@ protected:
     /// <summary>
     /// プレイヤーのステートごとの座標修正
     /// </summary>
+    /// Fixed:オーバーライドさせている分のifをベース側の関数でまとめて
+    ///       加算する符号、オフセット量、再生速度、引数で受け取れるようにする
     virtual void UpdateOffsetValue();
 
     /// <summary>

--- a/PlayerStateBase.h
+++ b/PlayerStateBase.h
@@ -81,7 +81,7 @@ protected:
     /// <summary>
     /// プレイヤーのステートごとの座標修正
     /// </summary>
-    /// Fixed:オーバーライドさせている分のifをベース側の関数でまとめて
+    /// TODO :オーバーライドさせている分のifをベース側の関数でまとめて
     ///       加算する符号、オフセット量、再生速度、引数で受け取れるようにする
     virtual void UpdateOffsetValue();
 

--- a/PlayerStateBase.h
+++ b/PlayerStateBase.h
@@ -64,6 +64,8 @@ public:
 
     // Getter
     const AnimationData GetStateAnimationData()const { return nowStateData; }
+    const float GetAnimationFactor()const { return animationFactor; }
+    const VECTOR GetStateOffseValue()const { return stateOffsetValue; }
 
 protected:
     /// <summary>
@@ -82,12 +84,18 @@ protected:
     /// </summary>
     virtual void FixedPosition();
 
+    /// <summary>
+    /// アニメーションデータの更新
+    /// </summary>
+    void UpdateAnimationData();
+
     //---------------------------------------------------------------------------------//
     //                                      定数                                       //
     //---------------------------------------------------------------------------------//
-    static constexpr float  MaxAnimationBlendRate   = 1.0f;     // アニメーションのブレンド率の最大値
-    static constexpr int    NoAnimationAttached     = -1;       // アニメーションアタッチがされていない
-    static constexpr float  AnimationFactorSpeed    = 0.1f;     // プログラムで作成したアニメーションの適用率
+    static constexpr float  MaxAnimationBlendRate   = 1.0f;         // アニメーションのブレンド率の最大値
+    static constexpr int    NoAnimationAttached     = -1;           // アニメーションアタッチがされていない
+    static constexpr float  AnimationFactorSpeed    = 0.1f;         // プログラムで作成したアニメーションの適用率
+    static constexpr VECTOR AnimationOffsetValue    = { 0,-0.5f,0 };    // 基本のずらし量(ステートごとにずらす量を定義する)
 
     //---------------------------------------------------------------------------------//
     //                                      変数                                       //
@@ -106,5 +114,6 @@ protected:
     float           playAnimationSpeed;         // アニメーション再生速度
     AnimationData   nowStateData;               // 次のステートへ渡す情報
     float           animationFactor;            // アニメーションの適用率
+    VECTOR          stateOffsetValue;           // ステートごとのプレイヤーずらし量
 };
 

--- a/PlayerStateBase.h
+++ b/PlayerStateBase.h
@@ -37,6 +37,7 @@ public:
         float       currentAnimationCount;      // 再生しているアニメーションの再生時間
         int         previousPlayAnimation;      // 前の再生アニメーションのアタッチ番号( -1:何もアニメーションがアタッチされていない )
         float       previousAnimationCount;     // 前の再生アニメーションの再生時間
+        float       animationFactor;            // アニメーションの適用率
     };
 
     /// <summary>
@@ -76,11 +77,17 @@ protected:
     /// </summary>
     void UpdateAnimation();
 
+    /// <summary>
+    /// プレイヤーのステートごとの座標修正
+    /// </summary>
+    virtual void FixedPosition();
+
     //---------------------------------------------------------------------------------//
     //                                      定数                                       //
     //---------------------------------------------------------------------------------//
     static constexpr float  MaxAnimationBlendRate   = 1.0f;     // アニメーションのブレンド率の最大値
     static constexpr int    NoAnimationAttached     = -1;       // アニメーションアタッチがされていない
+    static constexpr float  AnimationFactorSpeed    = 0.1f;     // プログラムで作成したアニメーションの適用率
 
     //---------------------------------------------------------------------------------//
     //                                      変数                                       //
@@ -98,5 +105,6 @@ protected:
     float           animationBlendSpeed;        // アニメーションのブレンド速度
     float           playAnimationSpeed;         // アニメーション再生速度
     AnimationData   nowStateData;               // 次のステートへ渡す情報
+    float           animationFactor;            // アニメーションの適用率
 };
 

--- a/PlayerStateBase.h
+++ b/PlayerStateBase.h
@@ -64,8 +64,7 @@ public:
 
     // Getter
     const AnimationData GetStateAnimationData()const { return nowStateData; }
-    const float GetAnimationFactor()const { return animationFactor; }
-    const VECTOR GetStateOffseValue()const { return stateOffsetValue; }
+    const VECTOR GetStateOffsetValue()const { return stateOffsetValue; }
 
 protected:
     /// <summary>

--- a/PlayerStateBase.h
+++ b/PlayerStateBase.h
@@ -82,7 +82,7 @@ protected:
     /// <summary>
     /// プレイヤーのステートごとの座標修正
     /// </summary>
-    virtual void FixedPosition();
+    virtual void UpdateOffsetValue();
 
     /// <summary>
     /// アニメーションデータの更新

--- a/PlayerWalkState.cpp
+++ b/PlayerWalkState.cpp
@@ -37,6 +37,9 @@ PlayerWalkState::~PlayerWalkState()
 /// </summary>
 void PlayerWalkState::Update()
 {
+    // プレイヤーの座標修正
+    FixedPosition();
+
     // アニメーションの更新
     UpdateAnimation();
 
@@ -44,14 +47,4 @@ void PlayerWalkState::Update()
     UpdateAnimationData();
 }
 
-/// <summary>
-/// アニメーションデータの更新
-/// </summary>
-void PlayerWalkState::UpdateAnimationData()
-{
-    nowStateData.currentAnimationCount  = currentAnimationCount;
-    nowStateData.currentPlayAnimation   = currentPlayAnimation;
-    nowStateData.previousAnimationCount = previousAnimationCount;
-    nowStateData.previousPlayAnimation  = previousPlayAnimation;
-}
 

--- a/PlayerWalkState.cpp
+++ b/PlayerWalkState.cpp
@@ -38,7 +38,7 @@ PlayerWalkState::~PlayerWalkState()
 void PlayerWalkState::Update()
 {
     // プレイヤーの座標修正
-    FixedPosition();
+    UpdateOffsetValue();
 
     // アニメーションの更新
     UpdateAnimation();

--- a/PlayerWalkState.h
+++ b/PlayerWalkState.h
@@ -31,10 +31,6 @@ public:
     void Update() override;
 
 private:
-    /// <summary>
-    /// アニメーションデータの更新
-    /// </summary>
-    void UpdateAnimationData();
 
     // アニメーション
     static constexpr float  PlayAnimationSpeed  = 0.5f;     // アニメーション速度

--- a/SubmachineGun.cpp
+++ b/SubmachineGun.cpp
@@ -11,6 +11,7 @@
 /// コンストラクタ
 /// </summary>
 SubmachineGun::SubmachineGun()
+    : runAnimationLerpFactor        (0.0f)
 {
     modelDataManager = ModelDataManager::GetInstance();
     Initialize();
@@ -77,6 +78,9 @@ void SubmachineGun::Update(VECTOR setPosition, VECTOR cameraVector, VECTOR camer
     // 弾丸の更新
     UpdateShooting(cameraPosition,cameraTargetVector);
 
+    // プレイヤーが走っているときアニメーション再生
+    PlayRunAnimation(playerState);
+
     // 移動更新
     UpdateMove(setPosition, playerState);
 }
@@ -90,13 +94,40 @@ void SubmachineGun::UpdateMove(VECTOR setPosition, Player::State playerState)
 {
     // Runステート用の座標
     VECTOR movePosition = position;
-    if (playerState == Player::State::Run)
-    {
-        movePosition = VAdd(movePosition, Player::RunAnimationOffset);
-    }
+
+    // 現在の適用率に基づいてオフセットを計算
+    VECTOR offset = VScale(Player::RunAnimationOffset, runAnimationLerpFactor);
+    movePosition = VAdd(position, offset);
 
     // 座標の設定
     MV1SetPosition(modelHandle, movePosition);
+}
+
+/// <summary>
+/// 走りのアンメーション再生
+/// </summary>
+/// <param name="playerState">プレイヤーのステート</param>
+void SubmachineGun::PlayRunAnimation(Player::State playerState)
+{
+    // 走りアニメーション時の処理
+    if (playerState == Player::State::Run)
+    {
+        // アニメーションの適用率を増加させる
+        runAnimationLerpFactor += Player::RunAnimationFactorSpeed;
+        if (runAnimationLerpFactor > 1.0f)
+        {
+            runAnimationLerpFactor = 1.0f;
+        }
+    }
+    else
+    {
+        // 他の状態に移行した場合、適用率を減少させる
+        runAnimationLerpFactor -= Player::RunAnimationFactorSpeed;
+        if (runAnimationLerpFactor < 0.0f)
+        {
+            runAnimationLerpFactor = 0.0f;
+        }
+    }
 }
 
 /// <summary>

--- a/SubmachineGun.cpp
+++ b/SubmachineGun.cpp
@@ -63,7 +63,7 @@ void SubmachineGun::Initialize()
 /// 更新
 /// </summary>
 void SubmachineGun::Update(VECTOR setPosition, VECTOR cameraVector, VECTOR cameraTargetVector,
-     VECTOR cameraPosition, float cameraPitch)
+     VECTOR cameraPosition, float cameraPitch, Player::State playerState)
 {
     // 座標を更新
     position = VAdd(setPosition, GunOffset);
@@ -72,14 +72,31 @@ void SubmachineGun::Update(VECTOR setPosition, VECTOR cameraVector, VECTOR camer
     //FixedGunPosition(setPosition, cameraVector);
 
     // 角度を更新
-    UpdateAngle(cameraVector, cameraPitch);
+    UpdateAngle(cameraVector, cameraPitch,playerState);
 
     // 弾丸の更新
     UpdateShooting(cameraPosition,cameraTargetVector);
 
+    // 移動更新
+    UpdateMove(setPosition, playerState);
+}
+
+/// <summary>
+/// 移動の更新
+/// </summary>
+/// <param name="setPosition">設定したい座標</param>
+/// <param name="playerState">プレイヤーの状態</param>
+void SubmachineGun::UpdateMove(VECTOR setPosition, Player::State playerState)
+{
+    // Runステート用の座標
+    VECTOR movePosition = position;
+    if (playerState == Player::State::Run)
+    {
+        movePosition = VAdd(movePosition, Player::RunAnimationOffset);
+    }
 
     // 座標の設定
-    MV1SetPosition(modelHandle, position);
+    MV1SetPosition(modelHandle, movePosition);
 }
 
 /// <summary>

--- a/SubmachineGun.h
+++ b/SubmachineGun.h
@@ -59,6 +59,12 @@ private:
     /// </summary>
     void UpdateShooting(VECTOR cameraPosition,VECTOR targetPosition);
 
+    /// <summary>
+    /// 走りのアニメーション再生
+    /// </summary>
+    /// <param name="playerState">プレイヤーのステート</param>
+    void PlayRunAnimation(Player::State playerState);
+
     //---------------------------------------------------------------------------------//
     //                                      定数                                       //
     //---------------------------------------------------------------------------------//
@@ -81,5 +87,6 @@ private:
     //                                      変数                                       //
     //---------------------------------------------------------------------------------//
     ModelDataManager*       modelDataManager;   // モデルデータ読み込み用クラスのアドレス
+    float                   runAnimationLerpFactor;
 };
 

--- a/SubmachineGun.h
+++ b/SubmachineGun.h
@@ -86,7 +86,7 @@ private:
     //---------------------------------------------------------------------------------//
     //                                      変数                                       //
     //---------------------------------------------------------------------------------//
-    ModelDataManager*       modelDataManager;   // モデルデータ読み込み用クラスのアドレス
-    float                   runAnimationLerpFactor;
+    ModelDataManager*       modelDataManager;           // モデルデータ読み込み用クラスのアドレス
+    float                   runAnimationLerpFactor;     // 走りアニメーション再生時の適応率
 };
 

--- a/SubmachineGun.h
+++ b/SubmachineGun.h
@@ -78,10 +78,10 @@ private:
     static constexpr int    GunFireRate             = 5;            // 銃の連射力(このフレームに１回発射する)
     static constexpr float  GunRecoil               = 1.0f;         // 銃の反動
     static constexpr float  GunAccuracy             = 1.0f;         // 銃の精度(拡散度合い)
-    static constexpr VECTOR InitializeScale         = { 0.07f,0.07f,0.07f };   // 初期化時のスケール
+    static constexpr VECTOR InitializeScale         = { 0.07f,0.07f,0.07f };    // 初期化時のスケール
     // ずらし量
     static constexpr VECTOR GunOffset = { 0.0f,0.5f,0.0f };   // 銃のプレイヤーの腕からのずらし量
-
+    
 
     //---------------------------------------------------------------------------------//
     //                                      変数                                       //

--- a/SubmachineGun.h
+++ b/SubmachineGun.h
@@ -39,7 +39,7 @@ public:
     /// <param name="cameraVector">カメラの前ベクトル</param>
     /// <param name="cameraPitch">カメラの水平からの角度</param>
     void Update(VECTOR setPosition,VECTOR cameraVector, VECTOR cameraTargetVector,
-        VECTOR cameraPosition,float cameraPitch);
+        VECTOR cameraPosition,float cameraPitch, Player::State);
 
     /// <summary>
     /// 描画
@@ -47,6 +47,13 @@ public:
     void Draw() override;
 
 private:
+    /// <summary>
+    /// 移動の更新
+    /// </summary>
+    /// <param name="setPosition">設定したい座標</param>
+    /// <param name="playerState">プレイヤーの状態</param>
+    void UpdateMove(VECTOR setPosition, Player::State playerState) override;
+
     /// <summary>
     /// 銃を発砲する
     /// </summary>


### PR DESCRIPTION
プレイヤーが走り状態のとき、プレイヤーと銃を下に下げるように変更しました。

プレイヤーモデルに走りのアニメーションがなかったため、プレイヤーの走りステート時にプレイヤー、銃ともに左右回転とY軸のみ下方向へ移動させ、走っているように見せています。