### PR TITLE
エネミーのOnHit関数、ウェーブステート切り替えを実装

### DIFF
--- a/Bullet.cpp
+++ b/Bullet.cpp
@@ -64,7 +64,6 @@ void Bullet::Update()
 
     // 弾丸は１フレームのみ存在する
     isActive = false;                           // 未使用のプールに戻す
-    collisionData.isCollisionActive = false;    // 当たり判定をなくす
 }
 
 /// <summary>

--- a/Bullet.h
+++ b/Bullet.h
@@ -63,6 +63,7 @@ public:
 
     // ゲッター、セッター
     const bool GetIsActive()const { return isActive; }
+    void SetCollisionDataIsActive(bool set) { collisionData.isCollisionActive = set; }
 
 private:
     //---------------------------------------------------------------------------------//

--- a/BulletObjectPools.cpp
+++ b/BulletObjectPools.cpp
@@ -74,6 +74,9 @@ void BulletObjectPools::ReturnActiveBulletInstance(list<Bullet*>& activeBullet)
         // 弾丸が使用中でない場合、未使用リストに移動する
         if (!bullet->GetIsActive())
         {
+            // 弾丸の当たり判定を非アクティブ化する
+            bullet->SetCollisionDataIsActive(false);
+
             // 弾丸を未使用リストに移動
             inactiveBullet.splice(inactiveBullet.end(), activeBullet, it++);
         }

--- a/Calculation.cpp
+++ b/Calculation.cpp
@@ -1,0 +1,31 @@
+﻿#include "Calculation.h"
+
+
+/// <summary>
+/// コンストラクタ
+/// </summary>
+Calculation::Calculation()
+{
+    // 処理なし
+}
+
+/// <summary>
+/// デストラクタ
+/// </summary>
+Calculation::~Calculation()
+{
+    // 処理なし
+}
+
+/// <summary>
+/// ２点間の距離を計算
+/// </summary>
+/// <param name="position1">点１</param>
+/// <param name="position2">点２</param>
+/// <returns>２点間の距離</returns>
+float Calculation::Distance3D(VECTOR position1, VECTOR position2)
+{
+    return sqrt((position2.x - position1.x) * (position2.x - position1.x) +
+                (position2.y - position1.y) * (position2.y - position1.y) +
+                (position2.z - position1.z) * (position2.z - position1.z));
+}

--- a/Calculation.h
+++ b/Calculation.h
@@ -1,0 +1,32 @@
+﻿#pragma once
+#include "Common.h"
+
+/// <summary>
+/// 計算クラス
+/// </summary>
+class Calculation
+{
+public:
+    /// <summary>
+    /// コンストラクタ
+    /// </summary>
+    Calculation();
+
+    /// <summary>
+    /// デストラクタ
+    /// </summary>
+    ~Calculation();
+
+    /// <summary>
+    /// ２点間の距離を計算
+    /// </summary>
+    /// <param name="position1">点１</param>
+    /// <param name="position2">点２</param>
+    /// <returns>２点間の距離</returns>
+    static float Distance3D(VECTOR position1, VECTOR position2);
+
+private:
+
+};
+
+

--- a/CollisionData.h
+++ b/CollisionData.h
@@ -12,12 +12,13 @@ struct CapsuleCollisionData;
 /// </summary>
 enum class ObjectTag : int
 {
-    Player,     // プレイヤー
-    Enemy,      // エネミー
-    EnemyHead,  // エネミーの頭
-    EnemyBoby,  // エネミーの胴体
-    Bullet,     // 弾丸
-    RoomCenter, // 部屋の中心
+    Player,         // プレイヤー
+    Enemy,          // エネミー
+    EnemyHead,      // エネミーの頭
+    EnemyBoby,      // エネミーの胴体
+    Bullet,         // 弾丸
+    RoomCenter,     // 部屋の中心
+    EnemyAttack,    // エネミーの攻撃
 };
 
 /// <summary>
@@ -28,6 +29,7 @@ struct CollisionData
     ObjectTag   tag;                    // このオブジェクトが何なのかのタグ(Player、Enemy、Bullet）
     // 球用
     VECTOR      centerPosition;         // 球の中心座標
+    float       attackPower;            // このオブジェクトの攻撃力
 
     // カプセル用
     VECTOR      startPosition;          // カプセルを形成し始める座標

--- a/CollisionData.h
+++ b/CollisionData.h
@@ -17,6 +17,7 @@ enum class ObjectTag : int
     EnemyHead,  // エネミーの頭
     EnemyBoby,  // エネミーの胴体
     Bullet,     // 弾丸
+    RoomCenter, // 部屋の中心
 };
 
 /// <summary>

--- a/CollisionManager.cpp
+++ b/CollisionManager.cpp
@@ -106,6 +106,18 @@ void CollisionManager::Update()
 
             }
 
+            //プレイヤーとエネミーの攻撃
+            if (data1.tag == ObjectTag::Player && data2.tag == ObjectTag::EnemyAttack)
+            {
+                // 球どおしの当たり判定
+                if (IsCollisionSphere(data1.centerPosition, data1.radius, data2.centerPosition, data2.radius))
+                {
+                    // 当たった後の関数を呼び出す
+                    data1.onHit(data2);
+                    data2.onHit(data1);
+                }
+            }
+
             // 球体とカプセル
 
             // カプセルとライン

--- a/CollisionManager.cpp
+++ b/CollisionManager.cpp
@@ -80,48 +80,52 @@ void CollisionManager::Update()
             CollisionData data1 = *collisionDataList[i];
             CollisionData data2 = *collisionDataList[j];
 
-            // エネミーと弾丸の当たり判定(カプセル対線分の当たり判定)
-            if (data1.tag == ObjectTag::EnemyBoby && data2.tag == ObjectTag::Bullet)
+            // 当たり判定を行って欲しいか確認
+            if (data1.isCollisionActive && data2.isCollisionActive)
             {
-                if (IsCollisionCapsuleLine(data1.startPosition,data1.endPosition,data1.radius,
-                                            data2.lineStartPosition,data2.lineEndPosition))
+                // エネミーと弾丸の当たり判定(カプセル対線分の当たり判定)
+                if (data1.tag == ObjectTag::EnemyBoby && data2.tag == ObjectTag::Bullet)
                 {
-                    // 当たった時の関数を呼び出す
-                   data1.onHit(data2);
-                   data2.onHit(data1);
-                }
-            }
-
-            // エネミーとエネミーの当たり判定(カプセルとカプセル)
-            if (data1.tag == ObjectTag::EnemyBoby && data2.tag == ObjectTag::EnemyBoby)
-            {
-                // カプセル同士の当たり判定処理
-                if (IsCollisionCapsuleCapsule(data1.startPosition,data1.endPosition,data1.radius,
-                    data2.startPosition,data2.endPosition,data2.radius))
-                {
-                    // 当たった時の関数を呼び出す
-                    data1.onHit(data2);
-                    data2.onHit(data1);
+                    if (IsCollisionCapsuleLine(data1.startPosition,data1.endPosition,data1.radius,
+                                                data2.lineStartPosition,data2.lineEndPosition))
+                    {
+                        // 当たった時の関数を呼び出す
+                       data1.onHit(data2);
+                       data2.onHit(data1);
+                    }
                 }
 
-            }
-
-            //プレイヤーとエネミーの攻撃
-            if (data1.tag == ObjectTag::Player && data2.tag == ObjectTag::EnemyAttack)
-            {
-                // 球どおしの当たり判定
-                if (IsCollisionSphere(data1.centerPosition, data1.radius, data2.centerPosition, data2.radius))
+                // エネミーとエネミーの当たり判定(カプセルとカプセル)
+                if (data1.tag == ObjectTag::EnemyBoby && data2.tag == ObjectTag::EnemyBoby)
                 {
-                    // 当たった後の関数を呼び出す
-                    data1.onHit(data2);
-                    data2.onHit(data1);
+                    // カプセル同士の当たり判定処理
+                    if (IsCollisionCapsuleCapsule(data1.startPosition,data1.endPosition,data1.radius,
+                        data2.startPosition,data2.endPosition,data2.radius))
+                    {
+                        // 当たった時の関数を呼び出す
+                        data1.onHit(data2);
+                        data2.onHit(data1);
+                    }
+
                 }
+
+                //プレイヤーとエネミーの攻撃
+                if (data1.tag == ObjectTag::Player && data2.tag == ObjectTag::EnemyAttack)
+                {
+                    // 球どおしの当たり判定
+                    if (IsCollisionSphere(data1.centerPosition, data1.radius, data2.centerPosition, data2.radius))
+                    {
+                        // 当たった後の関数を呼び出す
+                        data1.onHit(data2);
+                        data2.onHit(data1);
+                    }
+                }
+
+                // 球体とカプセル
+
+                // カプセルとライン
+
             }
-
-            // 球体とカプセル
-
-            // カプセルとライン
-
 
             // 当たり判定を消してほしい場合
             if (!collisionDataList[i]->isCollisionActive)

--- a/Common.h
+++ b/Common.h
@@ -20,3 +20,4 @@ static const int ScreenHeightHalf       = ScreenHeight / 2;             // 画�
 const int        DebugFontColor         = GetColor(255, 255, 225);      // デバッグ時のフォントの色(白)
 const int        DebugPolygonColorRed   = GetColor(200, 0, 0);          // デバッグ時のポリゴンの色(赤)
 const int        DebugPolygonColorBlue  = GetColor(0, 0,200);           // デバッグ時のポリゴンの色(青)
+static const int DebugSphereDivision    = 16;                           // デバッグ時のポリゴンの細かさ

--- a/Enemy.cpp
+++ b/Enemy.cpp
@@ -161,36 +161,6 @@ void Enemy::OnHit(CollisionData hitObjectData)
     case ObjectTag::EnemyBoby:  // エネミーと当たった時
         // 押し出し処理を行う
 
-        //// 半径の合計
-        //radiusSum = hitObjectData.radius + collisionData.radius;
-
-        //// y座標は変更しなくていいので０に修正する
-        //VECTOR correctedTargetPosition = VGet(hitObjectData.centerPosition.x, 0.0f, hitObjectData.centerPosition.z);
-
-        //// エネミーも同じように修正
-        //VECTOR correctedEnemyPosition = VGet(position.x, 0.0f, position.z);
-
-        //// 修正した座標からボスからプレイヤーの向きのベクトルを計算
-        //VECTOR vectorToPlayer = VSub(correctedEnemyPosition, correctedTargetPosition);
-
-        //// ベクトルのサイズを計算
-        //distance = VSize(vectorToPlayer);
-
-        //// 押し戻す距離の計算
-        //distance = radiusSum - distance;
-
-        //// ベクトルを正規化する
-        //vectorToPlayer = VNorm(vectorToPlayer);
-
-        //// 押し出す量
-        //VECTOR pushBackVector = VScale(vectorToPlayer, distance);
-
-        //// 計算したベクトルからプレイヤーの位置を変更
-        //position = VAdd(position, pushBackVector);
-
-        //// モデルの位置も合わせて修正
-        //MV1SetPosition(modelHandle, position);
-
         break;
 
     default:

--- a/Enemy.cpp
+++ b/Enemy.cpp
@@ -25,7 +25,7 @@ Enemy::Enemy()
     collisionManager = CollisionManager::GetInstance();
 
     // 初期化
-    Initialize();
+    //Initialize();
 }
 
 /// <summary>
@@ -161,27 +161,35 @@ void Enemy::OnHit(CollisionData hitObjectData)
     case ObjectTag::EnemyBoby:  // エネミーと当たった時
         // 押し出し処理を行う
 
-        // 進行方向を計算 (相手の位置から自分の位置を引いて方向ベクトルを求める)
-        VECTOR direction = VSub(position, hitObjectData.centerPosition);
+        //// 半径の合計
+        //radiusSum = hitObjectData.radius + collisionData.radius;
 
-        // 方向ベクトルを正規化する（長さを1にする）
-        direction = VNorm(direction);
-        direction.y = 0.0f;  // Y方向の成分を無視
+        //// y座標は変更しなくていいので０に修正する
+        //VECTOR correctedTargetPosition = VGet(hitObjectData.centerPosition.x, 0.0f, hitObjectData.centerPosition.z);
 
-        // 自分と相手の距離を計算
-        distance = VSize(VSub(position, hitObjectData.centerPosition));
+        //// エネミーも同じように修正
+        //VECTOR correctedEnemyPosition = VGet(position.x, 0.0f, position.z);
 
-        // 自分と相手の半径の合計
-        radiusSum = collisionData.radius + hitObjectData.radius;
+        //// 修正した座標からボスからプレイヤーの向きのベクトルを計算
+        //VECTOR vectorToPlayer = VSub(correctedEnemyPosition, correctedTargetPosition);
 
-        // めり込んだ分を計算 (半径の合計 - 距離)
-        penetrationDepth = radiusSum - distance;
+        //// ベクトルのサイズを計算
+        //distance = VSize(vectorToPlayer);
 
-        // めり込んだ分だけ方向に押し戻す
-        if (penetrationDepth > 0)
-        {
-            position = VAdd(position, VScale(direction, penetrationDepth));
-        }
+        //// 押し戻す距離の計算
+        //distance = radiusSum - distance;
+
+        //// ベクトルを正規化する
+        //vectorToPlayer = VNorm(vectorToPlayer);
+
+        //// 押し出す量
+        //VECTOR pushBackVector = VScale(vectorToPlayer, distance);
+
+        //// 計算したベクトルからプレイヤーの位置を変更
+        //position = VAdd(position, pushBackVector);
+
+        //// モデルの位置も合わせて修正
+        //MV1SetPosition(modelHandle, position);
 
         break;
 
@@ -212,6 +220,7 @@ void Enemy::UpdateCollisionData()
     // 座標をもとにカプセルを作成
     collisionData.startPosition = VAdd(position, CapsulePositionOffset);
     collisionData.endPosition = position;
+    collisionData.centerPosition = position;
 
     // カプセルの半径を登録
     collisionData.radius = CollisionRadius;

--- a/Enemy.cpp
+++ b/Enemy.cpp
@@ -130,17 +130,42 @@ void Enemy::OnHit(CollisionData hitObjectData)
         // HPを減少
         hitPoints -= hitObjectData.bulletPower;
 
+        // HPがゼロになった場合
+        if (hitPoints < 0)
+        {
+            isActive = false;
+        }
+
         break;
 
     case ObjectTag::EnemyBoby:  // エネミーと当たった時
         // 押し出し処理を行う
-        // 方向を計算
 
-        // 自分と相手の距離を図る
+        //// 進行方向を計算 (相手の位置から自分の位置を引いて方向ベクトルを求める)
+        //direction = VSub(position, hitObjectData.centerPosition);
 
-        // 自分と相手の半径の合計
+        //// 方向ベクトルを正規化する（長さを1にする）
+        //direction = VNorm(direction);
+        //direction.y = 0.0f;
 
-        // めり込んだ分だけ押し戻す
+        //// 進行方向の右方向ベクトルを計算
+        //VECTOR rightDirection = VCross(VGet(0.0f, 1.0f, 0.0f), direction);
+        //rightDirection = VNorm(rightDirection);
+
+        //// 自分と相手の距離を計算
+        //distance = VSize(VSub(position, hitObjectData.endPosition));
+
+        //// 自分と相手の半径の合計
+        //radiusSum = collisionData.radius + hitObjectData.radius;
+
+        //// めり込んだ分を計算 (半径の合計 - 距離)
+        //penetrationDepth = radiusSum - distance;
+
+        //// めり込んだ分だけ右方向に押し戻す
+        //if (penetrationDepth > 0)
+        //{
+        //    position = VAdd(position, VScale(rightDirection, penetrationDepth * 0.5f));
+        //}
 
         break;
 

--- a/Enemy.cpp
+++ b/Enemy.cpp
@@ -2,6 +2,7 @@
 #include "Enemy.h"
 #include "ModelDataManager.h"
 #include "Stage.h"
+#include "Calculation.h"
 
 /// <summary>
 /// コンストラクタ
@@ -83,7 +84,7 @@ void Enemy::Initialize()
 /// </summary>
 /// <param name="targetPosition">目標座標</param>
 /// <param name="stage">ステージ</param>
-void Enemy::Update(VECTOR targetPosition,Stage& stage)
+void Enemy::Update(VECTOR targetPosition,Stage& stage,ObjectTag targetTag)
 {
     // ルートフレームのＺ軸方向の移動パラメータを無効にする
     DisableRootFrameZMove();
@@ -97,6 +98,9 @@ void Enemy::Update(VECTOR targetPosition,Stage& stage)
 
     // 死んだかどうかのチェック
     UpdateDead();
+
+    // 攻撃の更新
+    UpdateAttack(targetPosition,targetTag);
 
     // アニメーション更新
     UpdateAnimation();
@@ -327,6 +331,28 @@ void Enemy::UpdateDead()
             isActive = false;
         }
     }
+}
+
+/// <summary>
+/// 攻撃の更新
+/// </summary>
+/// <param name="playerPosition">ターゲットの座標</param>
+void Enemy::UpdateAttack(VECTOR targetPosition, ObjectTag targetTag)
+{
+    // プレイヤーとエネミーとの距離を図る
+    if (targetTag == ObjectTag::Player)
+    {
+        // 距離を図る
+        float distance = Calculation::Distance3D(targetPosition, position);
+
+        // 距離が近ければ攻撃する
+        if (distance > 1.0f)
+        {
+
+        }
+
+    }
+
 }
 
 /// <summary>

--- a/Enemy.cpp
+++ b/Enemy.cpp
@@ -343,12 +343,36 @@ void Enemy::UpdateAttack(VECTOR targetPosition, ObjectTag targetTag)
     if (targetTag == ObjectTag::Player)
     {
         // 距離を図る
-        float distance = Calculation::Distance3D(targetPosition, position);
+        VECTOR playerPosition = targetPosition;
+        playerPosition.y = 1.0f;
+        float distance = Calculation::Distance3D(playerPosition, position);
 
         // 距離が近ければ攻撃する
-        if (distance > 1.0f)
+        if (distance < AttackRange)
         {
+            if (currentState != State::Attack)
+            {
+                // 攻撃アニメーション再生
+                PlayAnimation(AnimationType::Attack);
 
+                // 現在のステート更新
+                currentState = State::Attack;
+            }
+        }
+        else if (currentState == State::Attack)
+        {
+            // 再生しているアニメーションの総時間
+            float animationTotalTime = MV1GetAttachAnimTotalTime(modelHandle, currentPlayAnimation);
+
+            // 攻撃アニメーションが終了しているかチェック
+            if (currentAnimationCount >= animationTotalTime / 2)
+            {
+                // Runアニメーションに変更
+                PlayAnimation(AnimationType::Run);
+
+                // 現在のステートをRunに更新
+                currentState = State::Run;
+            }
         }
 
     }

--- a/Enemy.h
+++ b/Enemy.h
@@ -171,6 +171,7 @@ private:
     static constexpr int    InitializeHitPoints     = 100;                          // 初期化時の体力
     static constexpr VECTOR InitializeDirection     = { 1.0f, 0.0f, 0.0f };         // 初期化時の移動方向
     static constexpr int    DeathInactiveFrame      = 150;                          // 死亡してからモデルを削除するまでのフレームカウント数
+    static constexpr float  AttackRange             = 3.0f;                         // この範囲に入ったら攻撃を開始する
     // 当たり判定
     static constexpr float  CollisionRadius         = 1.0f;                         // 当たり判定用半径
     static constexpr VECTOR CapsulePositionOffset   = { 0.0f,4.0f,0.0f };           // カプセルの始点を作るためのずらし量

--- a/Enemy.h
+++ b/Enemy.h
@@ -80,6 +80,11 @@ public:
     /// </summary>
     void UpdateCollisionData();
 
+    /// <summary>
+    /// 攻撃の当たり判定に必要なデータの更新
+    /// </summary>
+    void UpdateAttackCollisionData();
+
     // Getter
     const VECTOR GetPosition()const { return position; }
     const Pathfinding::Room GetPreviousRoom()const { return previousRoom; }
@@ -147,6 +152,12 @@ private:
     void OnHit(CollisionData hitObjectData);
 
     /// <summary>
+    /// 攻撃がオブジェクトと接触した時の処理
+    /// </summary>
+    /// <param name="hitObjectData"></param>
+    void OnHitAttack(CollisionData hitObjectData);
+
+    /// <summary>
     /// 死んだかどうかチェックし、死んだ後の更新
     /// </summary>
     void UpdateDead();
@@ -176,6 +187,9 @@ private:
     static constexpr float  CollisionRadius         = 1.0f;                         // 当たり判定用半径
     static constexpr VECTOR CapsulePositionOffset   = { 0.0f,4.0f,0.0f };           // カプセルの始点を作るためのずらし量
     static constexpr float  PolygonDetail           = 8.0f;                         // 描画するポリゴンの数
+    // 攻撃
+    static constexpr float  AttackCollisionRadius   = 2.0f;                         // 攻撃の球型の当たり判定半径
+    static constexpr float  AttackPower             = 10.0f;                        // 攻撃力
     // 重力関係
     static constexpr float  Gravity                 = 3.0f;                         // 重力
     static constexpr float  FallUpPower             = 20.0f;                        // 足を踏み外した時のジャンプ力
@@ -214,6 +228,8 @@ private:
 
     // 当たり判定用
     CollisionData           collisionData;          // 当たり判定用情報
+    CollisionData           attackCollisionData;    // 攻撃時の当たり判定情報
+
 
     // アニメーション情報
     int         currentPlayAnimation;       // 再生しているアニメーションのアタッチ番号( -1:何もアニメーションがアタッチされていない )

--- a/Enemy.h
+++ b/Enemy.h
@@ -23,6 +23,7 @@ public:
         Walk,       // 歩き
         Run,        // 走り
         Attack,     // 攻撃
+        Death,      // 死亡
     };
 
     /// <summary>
@@ -145,6 +146,11 @@ private:
     /// <param name="hitObjectData">オブジェクトのデータ</param>
     void OnHit(CollisionData hitObjectData);
 
+    /// <summary>
+    /// 死んだかどうかチェックし、死んだ後の更新
+    /// </summary>
+    void UpdateDead();
+
     //---------------------------------------------------------------------------------//
     //                                      定数                                       //
     //---------------------------------------------------------------------------------//
@@ -158,6 +164,7 @@ private:
     static constexpr VECTOR EnemyScale              = { 0.03f,0.03f,0.03f };        // プレイヤーのスケール
     static constexpr int    InitializeHitPoints     = 100;                          // 初期化時の体力
     static constexpr VECTOR InitializeDirection     = { 1.0f, 0.0f, 0.0f };         // 初期化時の移動方向
+    static constexpr int    DeathInactiveFrame      = 150;                          // 死亡してからモデルを削除するまでのフレームカウント数
     // 当たり判定
     static constexpr float  CollisionRadius         = 1.0f;                         // 当たり判定用半径
     static constexpr VECTOR CapsulePositionOffset   = { 0.0f,4.0f,0.0f };           // カプセルの始点を作るためのずらし量
@@ -187,9 +194,10 @@ private:
     int         modelHandle;                // モデルハンドル
     int         shadowHandle;               // 影画像ハンドル
     bool        currentFrameMove;           // そのフレームで動いたかどうか
-    State       state;                      // 状態
+    State       currentState;               // 状態
     int         hitPoints;                  // 体力
-    bool        isActive;           // 使用中かどうか
+    bool        isActive;                   // 使用中かどうか
+    int         deathFrameCount;            // 死亡してから何フレーム経過するか
 
     // 線形探索用
     Pathfinding::Room previousRoom;                 // 以前いた部屋

--- a/Enemy.h
+++ b/Enemy.h
@@ -97,6 +97,7 @@ public:
     void SetTargetNextPosition(VECTOR set) { targetNextPosition = set; }
     void SetIsTouchingRoomCenter(bool set) { isTouchingRoomCenter = set; }
     void SetRoomEntryState(Pathfinding::RoomEntryState set) { roomEntryState = set; }
+    void SetCollisionDataIsActive(bool set) { collisionData.isCollisionActive = set; }
 
 private:
     /// <summary>

--- a/Enemy.h
+++ b/Enemy.h
@@ -183,7 +183,7 @@ private:
     static constexpr int    InitializeHitPoints     = 100;                          // 初期化時の体力
     static constexpr VECTOR InitializeDirection     = { 1.0f, 0.0f, 0.0f };         // 初期化時の移動方向
     static constexpr int    DeathInactiveFrame      = 150;                          // 死亡してからモデルを削除するまでのフレームカウント数
-    static constexpr float  AttackRange             = 3.0f;                         // この範囲に入ったら攻撃を開始する
+    static constexpr float  AttackRange             = 4.0f;                         // この範囲に入ったら攻撃を開始する
     // 当たり判定
     static constexpr float  CollisionRadius         = 1.0f;                         // 当たり判定用半径
     static constexpr VECTOR CapsulePositionOffset   = { 0.0f,4.0f,0.0f };           // カプセルの始点を作るためのずらし量

--- a/Enemy.h
+++ b/Enemy.h
@@ -68,7 +68,7 @@ public:
     /// </summary>
     /// <param name="targetPosition">目標座標</param>
     /// <param name="stage">ステージ</param>
-    void Update(VECTOR targetPosition, Stage& stage);
+    void Update(VECTOR targetPosition, Stage& stage, ObjectTag targetTag);
 
     /// <summary>
     /// 描画
@@ -150,6 +150,12 @@ private:
     /// 死んだかどうかチェックし、死んだ後の更新
     /// </summary>
     void UpdateDead();
+
+    /// <summary>
+    /// 攻撃の更新
+    /// </summary>
+    /// <param name="playerPosition">プレイヤーの座標</param>
+    void UpdateAttack(VECTOR targetPosition, ObjectTag targetTag);
 
     //---------------------------------------------------------------------------------//
     //                                      定数                                       //

--- a/EnemyGroup.cpp
+++ b/EnemyGroup.cpp
@@ -1,6 +1,6 @@
 ﻿#include "EnemyGroup.h"
 #include "Stage.h"
-
+#include"Calculation.h"
 
 /// <summary>
 /// コンストラクタ
@@ -56,10 +56,25 @@ void EnemyGroup::Update(VECTOR playerPosition, Stage& stage)
 
     for (int i = 0; i < enemys.size(); i++)
     {
+        // 線形探索
         VECTOR enemyTargetPosition = UpdateEnemyPathfinding(playerPosition, *enemys[i], stage);
 
+
+        // ターゲットがプレイヤーか部屋の中心座標かチェック
+        float distance = Calculation::Distance3D(playerPosition, enemyTargetPosition);
+        ObjectTag tag;
+
+        if (distance < 1.0f)
+        {
+            tag = ObjectTag::Player;
+        }
+        else
+        {
+            tag = ObjectTag::RoomCenter;
+        }
+
         // エネミーの更新
-        enemys[i]->Update(enemyTargetPosition,stage);
+        enemys[i]->Update(enemyTargetPosition,stage, tag);
     }
 
     for (int i = 0; i < enemys.size(); i++)

--- a/EnemyGroup.cpp
+++ b/EnemyGroup.cpp
@@ -142,3 +142,15 @@ VECTOR EnemyGroup::UpdateEnemyPathfinding(VECTOR playerPosition,Enemy& enemy, St
     // エネミーが目指す座標
     return enemyTargetPosition;
 }
+
+/// <summary>
+/// エネミーグループ内のエネミーのコリジョンデータを使用するかどうかを設定する
+/// </summary>
+/// <param name="set">使用したいかどうか</param>
+void EnemyGroup::SetCollisionDataIsActive(bool set)
+{
+    for (int i = 0; i < enemys.size(); i++)
+    {
+        enemys[i]->SetCollisionDataIsActive(set);
+    }
+}

--- a/EnemyGroup.h
+++ b/EnemyGroup.h
@@ -53,6 +53,9 @@ public:
     // Getter
     const bool GetIsActive()const { return isActive; }
 
+    // Setter
+    void SetCollisionDataIsActive(bool set);
+
 private:
     // 定数
 

--- a/EnemyGroupController.cpp
+++ b/EnemyGroupController.cpp
@@ -55,8 +55,9 @@ void EnemyGroupController::CreateEnemy()
     // 取得したエネミーがあるなら使用中に追加
     if (enemy != nullptr)
     {
-        enemy->Initialize();            // 初期化
-        activeEnemyGroup.push_back(enemy);    // エネミーの追加
+        enemy->Initialize();                    // 初期化
+        enemy->SetCollisionDataIsActive(true);  // 当たり判定をアクティブにする
+        activeEnemyGroup.push_back(enemy);      // エネミーの追加
     }
 
 }

--- a/EnemyGroupController.h
+++ b/EnemyGroupController.h
@@ -44,7 +44,7 @@ public:
     void Draw(VECTOR playerPosition);
 
     // Getter
-    const int GetEnemyGroupSize()const { return enemyGroup.size(); }
+    const int GetEnemyGroupSize()const { return activeEnemyGroup.size(); }
 
 private:
     // 定数

--- a/EnemyObjectPools.cpp
+++ b/EnemyObjectPools.cpp
@@ -72,6 +72,9 @@ void EnemyObjectPools::ReturnActiveEnemyInstance(list<EnemyGroup*>& activeEnemy)
         // エネミーが使用中出ない場合、未使用リストに移動する
         if (!enemy->GetIsActive())
         {
+            // エネミーの当たり判定を非アクティブ化する
+            enemy->SetCollisionDataIsActive(false);
+
             // エネミーを未使用リストに移動
             inactiveEnemy.splice(inactiveEnemy.end(), activeEnemy, it++);
         }

--- a/EnemyWaveController.cpp
+++ b/EnemyWaveController.cpp
@@ -10,6 +10,7 @@ EnemyWaveController::EnemyWaveController()
     , lastEnemySpawnTime    (0)
     , enemySpawnFlag        (false)
     , currentWaveSpawnCount (0)
+    , canSwichWave          (false)
 {
     // 現在のウェーブで出現するエネミーの数
     waveEnemySpawnCount = currentWaveState * EnemySpawnRate;
@@ -20,6 +21,7 @@ EnemyWaveController::EnemyWaveController()
 /// </summary>
 EnemyWaveController::~EnemyWaveController()
 {
+    // 処理なし
 }
 
 /// <summary>
@@ -37,7 +39,7 @@ void EnemyWaveController::Initialize()
 void EnemyWaveController::Update(int activeEnemyNumber)
 {
     // 現在使用中のエネミーがいない場合ウェーブを進める
-    if (activeEnemyNumber == 0)
+    if (activeEnemyNumber == 0 && canSwichWave)
     {
         // 次のウェーブに進む
         currentWaveState = static_cast<WaveState>(static_cast<int>(currentWaveState) + 1);
@@ -47,6 +49,7 @@ void EnemyWaveController::Update(int activeEnemyNumber)
         lastEnemySpawnTime = waveStartTime;     // 最後のエネミー出現時間を更新
         enemySpawnFlag = false;                 // 出現フラグをリセット
         currentWaveSpawnCount = 0;              // このウェーブで出現させたエネミーの数をリセット
+        canSwichWave = false;                   // 連続でウェーブが変わらないようにする
     }
 
     // 現在のウェーブの経過時間を計測
@@ -64,6 +67,9 @@ void EnemyWaveController::Update(int activeEnemyNumber)
                 // エネミーを出現させる処理
                 if (!enemySpawnFlag)
                 {
+                    // ウェーブを切り替え可能かどうか
+                    canSwichWave = true;
+
                     // 最後のエネミー出現時間を更新
                     lastEnemySpawnTime = GetNowCount();
 

--- a/EnemyWaveController.h
+++ b/EnemyWaveController.h
@@ -60,7 +60,7 @@ private:
     //                                      定数                                       //
     //---------------------------------------------------------------------------------//
     static constexpr int EnemySpawnLimit            = 15;   // 同時に存在できるエネミーの数
-    static constexpr int EnemySpawnResponseTime     = 1;    // 敵の出現頻度
+    static constexpr int EnemySpawnResponseTime     = 2;    // 敵の出現頻度
     static constexpr int EnemySpawnRate             = 5;    // 現在のウェーブにこの値を掛けてそのウェーブに出現するエネミーの数を決定する
     static constexpr int WaveDurationMS             = 1000; //
     static constexpr int EnemySpawnDelayMS          = 5000; // ウェーブが切り替わってからエネミーが出現するまでの時間
@@ -75,6 +75,7 @@ private:
     int         lastEnemySpawnTime;     // 最後にエネミーを出現させた時間
     bool        enemySpawnFlag;         // エネミーを出現させる指示
     int         currentWaveSpawnCount;  // 現在のウェーブで出現させたエネミーの数
+    bool        canSwichWave;           // ウェーブ切り替え可能かどうか
 };
 
 

--- a/GameScene.cpp
+++ b/GameScene.cpp
@@ -84,9 +84,6 @@ void GameScene::Initialize()
 /// <returns>次のシーンのポインタ</returns>
 SceneBase* GameScene::UpdateScene()
 {
-    // テスト描画
-    DrawFormatString(0, 0, GetColor(255, 255, 255), "GameScene", true);
-
     // オブジェクト更新
     input->Update();                                                // 入力処理
     player->Update(*input,*stage);                                  // プレイヤー

--- a/MyDxLibGame3D.vcxproj
+++ b/MyDxLibGame3D.vcxproj
@@ -22,6 +22,7 @@
     <ClCompile Include="AssaultRifle.cpp" />
     <ClCompile Include="BattleRifle.cpp" />
     <ClCompile Include="Boids.cpp" />
+    <ClCompile Include="Calculation.cpp" />
     <ClCompile Include="CollisionManager.cpp" />
     <ClCompile Include="Enemy.cpp" />
     <ClCompile Include="EnemyGroup.cpp" />
@@ -75,6 +76,7 @@
     <ClInclude Include="AssaultRifle.h" />
     <ClInclude Include="BattleRifle.h" />
     <ClInclude Include="Boids.h" />
+    <ClInclude Include="Calculation.h" />
     <ClInclude Include="CollisionData.h" />
     <ClInclude Include="CollisionManager.h" />
     <ClInclude Include="Enemy.h" />

--- a/MyDxLibGame3D.vcxproj.filters
+++ b/MyDxLibGame3D.vcxproj.filters
@@ -143,6 +143,9 @@
     <Filter Include="ZombiFPS\GameObject\Player\Gun\Bullet\BulletObjectPools">
       <UniqueIdentifier>{6cce4b7e-0999-4229-8afb-83e0eb06ca6f}</UniqueIdentifier>
     </Filter>
+    <Filter Include="ZombiFPS\System\Calculation">
+      <UniqueIdentifier>{e5e7b9c8-1775-4cf8-b012-8c5f2bf33226}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="Main.cpp">
@@ -297,6 +300,9 @@
     </ClCompile>
     <ClCompile Include="PlayerReloadState.cpp">
       <Filter>ZombiFPS\GameObject\Player\PlayerState\Status</Filter>
+    </ClCompile>
+    <ClCompile Include="Calculation.cpp">
+      <Filter>ZombiFPS\System\Calculation</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
@@ -455,6 +461,9 @@
     </ClInclude>
     <ClInclude Include="CollisionData.h">
       <Filter>ZombiFPS\CollisionManager</Filter>
+    </ClInclude>
+    <ClInclude Include="Calculation.h">
+      <Filter>ZombiFPS\System\Calculation</Filter>
     </ClInclude>
   </ItemGroup>
 </Project>

--- a/Player.cpp
+++ b/Player.cpp
@@ -619,6 +619,7 @@ void Player::UpdateShootingEquippedWeapon(const Input& input)
             if (bullet != nullptr)
             {
                 bullet->Initialize(initData);                       // 弾丸の初期化
+                bullet->SetCollisionDataIsActive(true);             // 当たり判定を適用する
                 equippedGun->GetActiveBullet().push_back(bullet);   // 弾丸の追加
             }
 

--- a/Player.h
+++ b/Player.h
@@ -1,6 +1,8 @@
 ﻿#pragma once
 #include "Common.h"
 #include "PlayerStateBase.h"
+#include "CollisionData.h"
+#include "CollisionManager.h"
 
 class PlayerStateBase;
 class GunBase;
@@ -91,6 +93,12 @@ public:
     /// </summary>
     void OnHitFloor();
 
+    /// <summary>
+    /// オブジェクトと接触した時の処理
+    /// </summary>
+    /// <param name="hitObjectData"></param>
+    void OnHitObject(CollisionData hitObjectData);
+
     //---------------------------------------------------------------------------------//
     //                                Getter/Setter                                    //
     //---------------------------------------------------------------------------------//
@@ -162,6 +170,11 @@ private:
     void UpdateAngle();
 
     /// <summary>
+    /// 当たり判定情報の更新
+    /// </summary>
+    void UpdateCollisionData();
+
+    /// <summary>
     /// アニメーションを新しく再生する
     /// </summary>
     /// <param name="type">アニメーションの種類</param>
@@ -208,6 +221,9 @@ private:
     static constexpr float  MoveLimitY              = 4.5f;                         // Y軸の移動制限
     static constexpr VECTOR ZeroVector              = { 0.0f,0.0f,0.0f };           // ゼロベクトル
     static constexpr VECTOR PlayerScale             = { 0.05f,0.05f,0.05f };        // プレイヤーのスケール
+    static constexpr float  InitializeHitPoint      = 50.0f;                        // プレイヤーの初期体力
+    // 当たり判定
+    static constexpr float  HitBoxRadius            = 3.0f;                         // 自身の当たり判定
     // 重力関係
     static constexpr float  Gravity                 = 3.0f;                         // 重力
     static constexpr float  FallUpPower             = 20.0f;                        // 足を踏み外した時のジャンプ力
@@ -226,7 +242,11 @@ private:
     //---------------------------------------------------------------------------------//
     // ロード関係
     ModelDataManager*   modelDataManager;   // モデルデータマネージャー
-    
+
+    // 当たり判定関係
+    CollisionManager*   collisionManager;   // 当たり判定管理クラス
+    CollisionData       collisionData;      // 当たり判定用情報
+
     // 基本情報
     PlayerCamera*       playerCamera;       // プレイヤー専用のカメラ(FPS視点カメラ)
     PlayerStateBase*    currentState;       // 現在のステート
@@ -234,6 +254,7 @@ private:
     BulletObjectPools*  bulletObjectPools;  // 弾丸のオブジェクトプール
     int                 shootFireRateCount; // 銃の連射力をカウント
     bool                isHitEnemyAttack;   // エネミーの攻撃を受けている
+    float               hitPoint;           // 体力
 
     // 移動状態
     VECTOR      position;                   // 座標

--- a/SubmachineGun.h
+++ b/SubmachineGun.h
@@ -78,7 +78,7 @@ private:
     //---------------------------------------------------------------------------------//
     // ステータス
     // 弾丸
-    static constexpr float  BulletDamagePower       = 1.0f;         // 弾丸の威力
+    static constexpr float  BulletDamagePower       = 10.0f;        // 弾丸の威力
     static constexpr float  BulletPenetrationPower  = 1.0f;         // 弾丸の貫通力
     static constexpr float  BulletSpeed             = 100.0f;       // 弾丸の速度
     static constexpr VECTOR BulletDirection         = { 0,0,1 };    // 弾丸の移動方向


### PR DESCRIPTION
・エネミーのOnHit関数を実装
・エネミーの死亡アニメーションを追加
・そのウェーブで出現するエネミーをすべて倒すと、ウェーブが進行するように修正

※エネミーの攻撃はまだ実装途中でまだ正常に機能しません